### PR TITLE
Fix empty avatar url handling

### DIFF
--- a/src/app/admin/characters/page.tsx
+++ b/src/app/admin/characters/page.tsx
@@ -62,15 +62,18 @@ export default function CharactersPage() {
   const columns: Column<(typeof characters)[number]>[] = [
     {
       header: 'Avatar',
-      accessor: (row) => (
-        <Image
-          src={row.avatarUrl}
-          alt={row.name}
-          width={40}
-          height={40}
-          className="rounded-full object-cover w-10 h-10"
-        />
-      ),
+      accessor: (row) =>
+        row.avatarUrl ? (
+          <Image
+            src={row.avatarUrl}
+            alt={row.name}
+            width={40}
+            height={40}
+            className="rounded-full object-cover w-10 h-10"
+          />
+        ) : (
+          <div className="w-10 h-10 rounded-full bg-gray-200" />
+        ),
     },
     { header: 'Name', accessor: (row) => row.name },
     { header: 'Description', accessor: (row) => row.description },


### PR DESCRIPTION
## Summary
- handle missing avatarUrl in characters table by rendering placeholder instead of empty Image

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6848cc16b7448326beb3159e501c31be