### PR TITLE
Add character editing page

### DIFF
--- a/src/app/admin/characters/[id]/page.tsx
+++ b/src/app/admin/characters/[id]/page.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { doc } from 'firebase/firestore'
+import { useDocument } from 'react-firebase-hooks/firestore'
+import Image from 'next/image'
+import { db } from '@/libs/firebase'
+import { updateCharacter } from '../actions'
+
+export default function EditCharacterPage() {
+  const { id } = useParams<{ id: string }>()
+  const router = useRouter()
+  const [value] = useDocument(id ? doc(db, 'characters', id) : undefined)
+  const data = value?.data() as { name: string; avatarUrl: string; description: string } | undefined
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [file, setFile] = useState<File | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (data) {
+      setName(data.name)
+      setDescription(data.description)
+    }
+  }, [data])
+
+  if (!data) return <div className="p-6">Loading...</div>
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    await updateCharacter(id, name, description, file ?? undefined)
+    setLoading(false)
+    router.push('/admin/characters')
+  }
+
+  return (
+    <div className="p-6 flex flex-col gap-4 max-w-md">
+      <h1 className="text-xl">編輯角色</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <Image
+          src={file ? URL.createObjectURL(file) : data.avatarUrl || 'https://placehold.co/80x80.png'}
+          alt={name}
+          width={80}
+          height={80}
+          className="rounded-full object-cover w-20 h-20"
+        />
+        <label className="flex flex-col gap-1">
+          名稱
+          <input
+            className="border rounded px-2 py-1"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          Avatar
+          <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+        </label>
+        <label className="flex flex-col gap-1">
+          對話規則
+          <textarea
+            className="border rounded px-2 py-1"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={4}
+          />
+        </label>
+        <button type="submit" disabled={loading} className="self-start px-4 py-2 bg-black text-white rounded disabled:opacity-50">
+          {loading ? '儲存中...' : '儲存'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/admin/characters/actions.ts
+++ b/src/app/admin/characters/actions.ts
@@ -1,5 +1,5 @@
 // src/app/admin/characters/actions.ts
-import { collection, addDoc } from 'firebase/firestore';
+import { collection, addDoc, doc, updateDoc } from 'firebase/firestore';
 import { db, storage, auth } from '@/libs/firebase';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { signInAnonymously } from 'firebase/auth';
@@ -19,4 +19,29 @@ export async function createCharacter(name: string, file: File) {
     avatarUrl: url,
     description: '',
   });
+}
+
+export async function updateCharacter(
+  id: string,
+  name: string,
+  description: string,
+  file?: File,
+) {
+  if (!auth.currentUser) {
+    await signInAnonymously(auth);
+  }
+
+  const data: { name: string; description: string; avatarUrl?: string } = {
+    name,
+    description,
+  };
+
+  if (file) {
+    const imgRef = ref(storage, `avatars/${crypto.randomUUID()}`);
+    await uploadBytes(imgRef, file);
+    const url = await getDownloadURL(imgRef);
+    data.avatarUrl = url;
+  }
+
+  await updateDoc(doc(db, 'characters', id), data);
 }

--- a/src/app/admin/characters/page.tsx
+++ b/src/app/admin/characters/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useCollection } from 'react-firebase-hooks/firestore'
 import { collection } from 'firebase/firestore'
 import { db } from '@/libs/firebase'
@@ -74,6 +75,14 @@ export default function CharactersPage() {
     },
     { header: 'Name', accessor: (row) => row.name },
     { header: 'Description', accessor: (row) => row.description },
+    {
+      header: '',
+      accessor: (row) => (
+        <Link href={`/admin/characters/${row.id}`} className="text-blue-500 underline">
+          編輯
+        </Link>
+      ),
+    },
   ]
 
   return (


### PR DESCRIPTION
## Summary
- implement `updateCharacter` action to update Firestore documents and optionally upload a new avatar
- add edit page for characters under `/admin/characters/[id]`
- show edit link in characters list table

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`, `Geist Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_684a38ce975c83269ba0c427f3884253