### PR TITLE
Implement mobile-first NPC chat UI

### DIFF
--- a/src/app/admin/characters/list.client.tsx
+++ b/src/app/admin/characters/list.client.tsx
@@ -114,6 +114,14 @@ export default function CharactersPage() {
     {
       header: '',
       accessor: (row) => (
+        <Link href={`/chat/${row.id}`} className="text-blue-500 underline">
+          聊天
+        </Link>
+      ),
+    },
+    {
+      header: '',
+      accessor: (row) => (
         <Link href={`/admin/characters/${row.id}`} className="text-blue-500 underline">
           編輯
         </Link>

--- a/src/app/api/chat/history/route.ts
+++ b/src/app/api/chat/history/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+import { conversations } from '../store'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const id = searchParams.get('conversationId') || ''
+  const messages = conversations.get(id) || []
+  return NextResponse.json({ messages })
+}

--- a/src/app/api/chat/history/route.ts
+++ b/src/app/api/chat/history/route.ts
@@ -4,6 +4,6 @@ import { conversations } from '../store'
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const id = searchParams.get('conversationId') || ''
-  const messages = conversations.get(id) || []
-  return NextResponse.json({ messages })
+  const convo = conversations.get(id)
+  return NextResponse.json({ messages: convo?.messages || [] })
 }

--- a/src/app/api/chat/history/route.ts
+++ b/src/app/api/chat/history/route.ts
@@ -5,5 +5,6 @@ export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const id = searchParams.get('conversationId') || ''
   const convo = conversations.get(id)
-  return NextResponse.json({ messages: convo?.messages || [] })
+  if (!convo) return new NextResponse('Not Found', { status: 404 })
+  return NextResponse.json({ messages: convo.messages })
 }

--- a/src/app/api/chat/init/route.ts
+++ b/src/app/api/chat/init/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server'
 import { conversations } from '../store'
 import type { ChatMessage } from '@/types/chat'
-import { characters } from '@/data/characters'
+import { getCharacter } from '@/data/characters'
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const characterId = searchParams.get('characterId') || 'default'
-  const character = characters[characterId] || characters.default
+  const character = await getCharacter(characterId)
   const conversationId = crypto.randomUUID()
   const messages: ChatMessage[] = [
     {

--- a/src/app/api/chat/init/route.ts
+++ b/src/app/api/chat/init/route.ts
@@ -8,16 +8,14 @@ export async function GET(req: Request) {
   const characterId = searchParams.get('characterId') || 'default'
   const character = await getCharacter(characterId)
   const conversationId = crypto.randomUUID()
-  const messages: ChatMessage[] = [
-    {
-      id: crypto.randomUUID(),
-      role: 'npc',
-      type: 'TEXT',
-      content: character.greeting,
-      avatarUrl: character.avatarUrl,
-      timestamp: new Date().toISOString(),
-    },
-  ]
-  conversations.set(conversationId, { characterId, messages })
+  const messages: ChatMessage[] = character.greeting.map((g) => ({
+    id: crypto.randomUUID(),
+    role: 'npc',
+    type: g.type === 'image' ? 'IMAGE' : 'TEXT',
+    content: g.value as string,
+    avatarUrl: character.avatarUrl,
+    timestamp: new Date().toISOString(),
+  }))
+  conversations.set(conversationId, { characterId, messages, counters: {} })
   return NextResponse.json({ conversationId, messages })
 }

--- a/src/app/api/chat/init/route.ts
+++ b/src/app/api/chat/init/route.ts
@@ -14,6 +14,9 @@ export async function GET(req: Request) {
     type: g.type === 'image' ? 'IMAGE' : 'TEXT',
     content: g.value as string,
     avatarUrl: character.avatarUrl,
+    avatarX: character.avatarX,
+    avatarY: character.avatarY,
+    avatarScale: character.avatarScale,
     timestamp: new Date().toISOString(),
   }))
   conversations.set(conversationId, { characterId, messages, counters: {} })

--- a/src/app/api/chat/init/route.ts
+++ b/src/app/api/chat/init/route.ts
@@ -1,20 +1,23 @@
 import { NextResponse } from 'next/server'
 import { conversations } from '../store'
 import type { ChatMessage } from '@/types/chat'
+import { characters } from '@/data/characters'
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const characterId = searchParams.get('characterId') || 'default'
+  const character = characters[characterId] || characters.default
   const conversationId = crypto.randomUUID()
   const messages: ChatMessage[] = [
     {
       id: crypto.randomUUID(),
       role: 'npc',
       type: 'TEXT',
-      content: `你好，我是 ${characterId}`,
+      content: character.greeting,
+      avatarUrl: character.avatarUrl,
       timestamp: new Date().toISOString(),
     },
   ]
-  conversations.set(conversationId, messages)
+  conversations.set(conversationId, { characterId, messages })
   return NextResponse.json({ conversationId, messages })
 }

--- a/src/app/api/chat/init/route.ts
+++ b/src/app/api/chat/init/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { conversations } from '../store'
+import type { ChatMessage } from '@/types/chat'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const characterId = searchParams.get('characterId') || 'default'
+  const conversationId = crypto.randomUUID()
+  const messages: ChatMessage[] = [
+    {
+      id: crypto.randomUUID(),
+      role: 'npc',
+      type: 'TEXT',
+      content: `你好，我是 ${characterId}`,
+      timestamp: new Date().toISOString(),
+    },
+  ]
+  conversations.set(conversationId, messages)
+  return NextResponse.json({ conversationId, messages })
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { conversations } from './store'
 import type { ChatMessage } from '@/types/chat'
-import { characters } from '@/data/characters'
+import { getCharacter } from '@/data/characters'
 
 export async function POST(req: Request) {
   const { conversationId, message } = await req.json()
@@ -20,7 +20,7 @@ export async function POST(req: Request) {
   }
   convo.messages.push(userMsg)
 
-  const character = characters[convo.characterId] || characters.default
+  const character = await getCharacter(convo.characterId)
   let replyText = character.defaultResponse
   for (const rule of character.rules) {
     if (rule.keywords.some((k) => message.includes(k))) {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -36,6 +36,9 @@ export async function POST(req: Request) {
     type: resp.type === 'image' ? 'IMAGE' : 'TEXT',
     content: resp.value as string,
     avatarUrl: character.avatarUrl,
+    avatarX: character.avatarX,
+    avatarY: character.avatarY,
+    avatarScale: character.avatarScale,
     timestamp: new Date().toISOString(),
   }))
   convo.messages.push(...npcReplies)

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,21 +1,41 @@
 import { NextResponse } from 'next/server'
 import { conversations } from './store'
 import type { ChatMessage } from '@/types/chat'
+import { characters } from '@/data/characters'
 
 export async function POST(req: Request) {
   const { conversationId, message } = await req.json()
   if (!conversationId || typeof message !== 'string') {
     return new NextResponse('Bad Request', { status: 400 })
   }
-  const msgs = conversations.get(conversationId)
-  if (!msgs) return new NextResponse('Not Found', { status: 404 })
+  const convo = conversations.get(conversationId)
+  if (!convo) return new NextResponse('Not Found', { status: 404 })
+
+  const userMsg: ChatMessage = {
+    id: crypto.randomUUID(),
+    role: 'user',
+    type: 'TEXT',
+    content: message,
+    timestamp: new Date().toISOString(),
+  }
+  convo.messages.push(userMsg)
+
+  const character = characters[convo.characterId] || characters.default
+  let replyText = character.defaultResponse
+  for (const rule of character.rules) {
+    if (rule.keywords.some((k) => message.includes(k))) {
+      replyText = rule.response
+      break
+    }
+  }
   const npcReply: ChatMessage = {
     id: crypto.randomUUID(),
     role: 'npc',
     type: 'TEXT',
-    content: `你說：${message}`,
+    content: replyText,
+    avatarUrl: character.avatarUrl,
     timestamp: new Date().toISOString(),
   }
-  msgs.push(npcReply)
+  convo.messages.push(npcReply)
   return NextResponse.json({ messages: [npcReply] })
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -22,27 +22,22 @@ export async function POST(req: Request) {
 
   const character = await getCharacter(convo.characterId)
   let responses = character.defaultResponses
-  let key = 'default'
   for (let i = 0; i < character.rules.length; i++) {
     const rule = character.rules[i]
     if (rule.keywords.some((k) => message.includes(k))) {
       responses = rule.responses
-      key = `rule${i}`
       break
     }
   }
-  const index = convo.counters[key] || 0
-  const resp = responses[index % responses.length]
-  convo.counters[key] = index + 1
 
-  const npcReply: ChatMessage = {
+  const npcReplies: ChatMessage[] = responses.map((resp) => ({
     id: crypto.randomUUID(),
     role: 'npc',
     type: resp.type === 'image' ? 'IMAGE' : 'TEXT',
     content: resp.value as string,
     avatarUrl: character.avatarUrl,
     timestamp: new Date().toISOString(),
-  }
-  convo.messages.push(npcReply)
-  return NextResponse.json({ messages: [npcReply] })
+  }))
+  convo.messages.push(...npcReplies)
+  return NextResponse.json({ messages: npcReplies })
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -21,18 +21,25 @@ export async function POST(req: Request) {
   convo.messages.push(userMsg)
 
   const character = await getCharacter(convo.characterId)
-  let replyText = character.defaultResponse
-  for (const rule of character.rules) {
+  let responses = character.defaultResponses
+  let key = 'default'
+  for (let i = 0; i < character.rules.length; i++) {
+    const rule = character.rules[i]
     if (rule.keywords.some((k) => message.includes(k))) {
-      replyText = rule.response
+      responses = rule.responses
+      key = `rule${i}`
       break
     }
   }
+  const index = convo.counters[key] || 0
+  const resp = responses[index % responses.length]
+  convo.counters[key] = index + 1
+
   const npcReply: ChatMessage = {
     id: crypto.randomUUID(),
     role: 'npc',
-    type: 'TEXT',
-    content: replyText,
+    type: resp.type === 'image' ? 'IMAGE' : 'TEXT',
+    content: resp.value as string,
     avatarUrl: character.avatarUrl,
     timestamp: new Date().toISOString(),
   }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import { conversations } from './store'
+import type { ChatMessage } from '@/types/chat'
+
+export async function POST(req: Request) {
+  const { conversationId, message } = await req.json()
+  if (!conversationId || typeof message !== 'string') {
+    return new NextResponse('Bad Request', { status: 400 })
+  }
+  const msgs = conversations.get(conversationId)
+  if (!msgs) return new NextResponse('Not Found', { status: 404 })
+  const npcReply: ChatMessage = {
+    id: crypto.randomUUID(),
+    role: 'npc',
+    type: 'TEXT',
+    content: `你說：${message}`,
+    timestamp: new Date().toISOString(),
+  }
+  msgs.push(npcReply)
+  return NextResponse.json({ messages: [npcReply] })
+}

--- a/src/app/api/chat/store.ts
+++ b/src/app/api/chat/store.ts
@@ -1,0 +1,13 @@
+import type { ChatMessage } from '@/types/chat'
+
+interface GlobalStore {
+  _conversations?: Map<string, ChatMessage[]>
+}
+
+const g = global as unknown as GlobalStore
+export const conversations: Map<string, ChatMessage[]> =
+  g._conversations || new Map<string, ChatMessage[]>()
+
+if (!g._conversations) {
+  g._conversations = conversations
+}

--- a/src/app/api/chat/store.ts
+++ b/src/app/api/chat/store.ts
@@ -1,12 +1,17 @@
 import type { ChatMessage } from '@/types/chat'
 
+export interface Conversation {
+  characterId: string
+  messages: ChatMessage[]
+}
+
 interface GlobalStore {
-  _conversations?: Map<string, ChatMessage[]>
+  _conversations?: Map<string, Conversation>
 }
 
 const g = global as unknown as GlobalStore
-export const conversations: Map<string, ChatMessage[]> =
-  g._conversations || new Map<string, ChatMessage[]>()
+export const conversations: Map<string, Conversation> =
+  g._conversations || new Map<string, Conversation>()
 
 if (!g._conversations) {
   g._conversations = conversations

--- a/src/app/api/chat/store.ts
+++ b/src/app/api/chat/store.ts
@@ -3,6 +3,7 @@ import type { ChatMessage } from '@/types/chat'
 export interface Conversation {
   characterId: string
   messages: ChatMessage[]
+  counters: Record<string, number>
 }
 
 interface GlobalStore {

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -24,14 +24,14 @@ export default function CharacterChatPage() {
   }
 
   return (
-    <div className="h-screen flex flex-col">
+    <div className="h-screen flex flex-col max-w-md mx-auto w-full">
       <header className="p-4 border-b flex justify-between items-center">
         <h1 className="font-semibold">NPC Chat</h1>
         <button className="text-sm text-red-600" onClick={clear}>
           清除
         </button>
       </header>
-      <div ref={listRef} className="flex-1 overflow-y-auto p-4 space-y-2">
+      <div ref={listRef} className="flex-1 overflow-y-auto p-4 space-y-2 pb-28">
         {messages.map((m: ChatMessage) => (
           <ChatBubble key={m.id} message={m} />
         ))}

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useRef, useState } from 'react'
+import Image from 'next/image'
 import { useParams } from 'next/navigation'
 import { doc } from 'firebase/firestore'
 import { useDocument } from 'react-firebase-hooks/firestore'
@@ -39,6 +40,23 @@ export default function CharacterChatPage() {
           清除
         </button>
       </header>
+      {data?.avatarUrl && (
+        <div className="flex justify-center p-4">
+          <div className="relative w-4/5 aspect-square overflow-hidden rounded-lg">
+            <Image
+              src={data.avatarUrl}
+              alt={data.name}
+              fill
+              className="object-cover"
+              style={{
+                transform: `translate(${data.avatarX ?? 0}%, ${data.avatarY ?? 0}%) scale(${
+                  data.avatarScale ?? 1
+                })`,
+              }}
+            />
+          </div>
+        </div>
+      )}
       <div ref={listRef} className="flex-1 overflow-y-auto p-4 space-y-2 pb-28">
         {messages.map((m: ChatMessage) => (
           <ChatBubble key={m.id} message={m} />

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -1,6 +1,10 @@
 'use client'
 import { useRef, useState } from 'react'
 import { useParams } from 'next/navigation'
+import { doc } from 'firebase/firestore'
+import { useDocument } from 'react-firebase-hooks/firestore'
+import { db } from '@/libs/firebase'
+import type { CharacterDoc } from '@/types'
 import { ChatBubble } from '@/components/ChatBubble'
 import type { ChatMessage } from '@/types/chat'
 import { useChat } from '@/hooks/useChat'
@@ -8,6 +12,10 @@ import { useChat } from '@/hooks/useChat'
 export default function CharacterChatPage() {
   const { id } = useParams<{ id: string }>()
   const characterId = id || 'default'
+  const [value] = useDocument(
+    characterId ? doc(db, 'characters', characterId) : undefined,
+  )
+  const data = value?.data() as CharacterDoc | undefined
   const { messages, send, clear, loading, error } = useChat(characterId)
   const [text, setText] = useState('')
   const listRef = useRef<HTMLDivElement | null>(null)
@@ -26,7 +34,7 @@ export default function CharacterChatPage() {
   return (
     <div className="h-screen flex flex-col max-w-md mx-auto w-full">
       <header className="p-4 border-b flex justify-between items-center">
-        <h1 className="font-semibold">NPC Chat</h1>
+        <h1 className="font-semibold">{data?.name || 'NPC Chat'}</h1>
         <button className="text-sm text-red-600" onClick={clear}>
           清除
         </button>

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 import { useRef, useState } from 'react'
 import { useParams } from 'next/navigation'
-import { ChatBubble, ChatMessage } from '@/components/ChatBubble'
+import { ChatBubble } from '@/components/ChatBubble'
+import type { ChatMessage } from '@/types/chat'
 import { useChat } from '@/hooks/useChat'
 
 export default function CharacterChatPage() {

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -1,0 +1,59 @@
+'use client'
+import { useRef, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { ChatBubble, ChatMessage } from '@/components/ChatBubble'
+import { useChat } from '@/hooks/useChat'
+
+export default function CharacterChatPage() {
+  const { id } = useParams<{ id: string }>()
+  const characterId = id || 'default'
+  const { messages, send, clear, loading, error } = useChat(characterId)
+  const [text, setText] = useState('')
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!text.trim()) return
+    send(text.trim())
+    setText('')
+    ;(document.activeElement as HTMLElement | null)?.blur()
+    setTimeout(() => {
+      listRef.current?.scrollTo(0, listRef.current.scrollHeight)
+    }, 50)
+  }
+
+  return (
+    <div className="h-screen flex flex-col">
+      <header className="p-4 border-b flex justify-between items-center">
+        <h1 className="font-semibold">NPC Chat</h1>
+        <button className="text-sm text-red-600" onClick={clear}>
+          清除
+        </button>
+      </header>
+      <div ref={listRef} className="flex-1 overflow-y-auto p-4 space-y-2">
+        {messages.map((m: ChatMessage) => (
+          <ChatBubble key={m.id} message={m} />
+        ))}
+        {loading && <p className="text-center text-sm text-gray-500">載入中...</p>}
+        {error && <p className="text-center text-sm text-red-600">{error}</p>}
+      </div>
+      <form
+        onSubmit={handleSubmit}
+        className="sticky bottom-0 bg-white dark:bg-neutral-900 p-4 flex gap-2 border-t"
+      >
+        <textarea
+          className="flex-1 border rounded p-2 resize-none h-10"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+          disabled={!text.trim()}
+        >
+          送出
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -32,7 +32,7 @@ export default function CharacterChatPage() {
   }
 
   return (
-    <div className="h-screen flex flex-col max-w-md mx-auto w-full">
+    <div className="h-dvh flex flex-col max-w-md mx-auto w-full bg-white">
       <header className="p-4 border-b flex justify-between items-center">
         <h1 className="font-semibold">{data?.name || 'NPC Chat'}</h1>
         <button className="text-sm text-red-600" onClick={clear}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">
+      <body className="antialiased bg-white">
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useRef, useState } from 'react'
-import { ChatBubble, ChatMessage } from '@/components/ChatBubble'
+import { ChatBubble } from '@/components/ChatBubble'
+import type { ChatMessage } from '@/types/chat'
 import { useChat } from '@/hooks/useChat'
 
 export default function ChatPage() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function ChatPage() {
   }
 
   return (
-    <div className="h-screen flex flex-col max-w-md mx-auto w-full">
+    <div className="h-dvh flex flex-col max-w-md mx-auto w-full bg-white">
       <header className="p-4 border-b flex justify-between items-center">
         <h1 className="font-semibold">NPC Chat</h1>
         <button

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function ChatPage() {
   }
 
   return (
-    <div className="h-screen flex flex-col">
+    <div className="h-screen flex flex-col max-w-md mx-auto w-full">
       <header className="p-4 border-b flex justify-between items-center">
         <h1 className="font-semibold">NPC Chat</h1>
         <button
@@ -32,7 +32,7 @@ export default function ChatPage() {
           清除
         </button>
       </header>
-      <div ref={listRef} className="flex-1 overflow-y-auto p-4 space-y-2">
+      <div ref={listRef} className="flex-1 overflow-y-auto p-4 space-y-2 pb-28">
         {messages.map((m: ChatMessage) => (
           <ChatBubble key={m.id} message={m} />
         ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,62 @@
-import Image from "next/image";
+'use client'
+import { useRef, useState } from 'react'
+import { ChatBubble, ChatMessage } from '@/components/ChatBubble'
+import { useChat } from '@/hooks/useChat'
 
-export default function Home() {
+export default function ChatPage() {
+  const characterId = 'default'
+  const { messages, send, clear, loading, error } = useChat(characterId)
+  const [text, setText] = useState('')
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!text.trim()) return
+    send(text.trim())
+    setText('')
+    ;(document.activeElement as HTMLElement | null)?.blur()
+    setTimeout(() => {
+      listRef.current?.scrollTo(0, listRef.current.scrollHeight)
+    }, 50)
+  }
+
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
+    <div className="h-screen flex flex-col">
+      <header className="p-4 border-b flex justify-between items-center">
+        <h1 className="font-semibold">NPC Chat</h1>
+        <button
+          className="text-sm text-red-600"
+          onClick={clear}
+        >
+          清除
+        </button>
+      </header>
+      <div ref={listRef} className="flex-1 overflow-y-auto p-4 space-y-2">
+        {messages.map((m: ChatMessage) => (
+          <ChatBubble key={m.id} message={m} />
+        ))}
+        {loading && <p className="text-center text-sm text-gray-500">載入中...</p>}
+        {error && (
+          <p className="text-center text-sm text-red-600">{error}</p>
+        )}
+      </div>
+      <form
+        onSubmit={handleSubmit}
+        className="sticky bottom-0 bg-white dark:bg-neutral-900 p-4 flex gap-2 border-t"
+      >
+        <textarea
+          className="flex-1 border rounded p-2 resize-none h-10"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
         />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+          disabled={!text.trim()}
         >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+          送出
+        </button>
+      </form>
     </div>
-  );
+  )
 }

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -1,0 +1,72 @@
+'use client'
+import Image from 'next/image'
+import React from 'react'
+
+export interface ChatMessage {
+  id: string
+  role: 'user' | 'npc'
+  type: 'TEXT' | 'IMAGE' | 'YOUTUBE'
+  content: string
+  timestamp?: string
+  avatarUrl?: string
+}
+
+export function ChatBubble({ message }: { message: ChatMessage }) {
+  const isUser = message.role === 'user'
+
+  function renderContent() {
+    switch (message.type) {
+      case 'IMAGE':
+        return (
+          <Image
+            src={message.content}
+            alt="image"
+            width={200}
+            height={200}
+            className="rounded-lg"
+          />
+        )
+      case 'YOUTUBE':
+        const id = message.content.split('v=')[1] || message.content
+        return (
+          <div className="relative w-64 sm:w-80 pt-[56.25%]">
+            <iframe
+              src={`https://www.youtube.com/embed/${id}`}
+              className="absolute inset-0 w-full h-full rounded-lg"
+              allowFullScreen
+            />
+          </div>
+        )
+      default:
+        return <span>{message.content}</span>
+    }
+  }
+
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} gap-2 mb-3`}>
+      {!isUser && (
+        <Image
+          src={message.avatarUrl || '/next.svg'}
+          alt="avatar"
+          width={32}
+          height={32}
+          className="rounded-full self-end"
+        />
+      )}
+      <div className="max-w-[70%]">
+        <div
+          className={`px-3 py-2 rounded-lg text-sm break-words ${
+            isUser ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-neutral-800'
+          }`}
+        >
+          {renderContent()}
+        </div>
+        {message.timestamp && (
+          <time className="block mt-1 text-xs text-gray-500 text-right">
+            {new Date(message.timestamp).toLocaleTimeString()}
+          </time>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -1,15 +1,7 @@
 'use client'
 import Image from 'next/image'
 import React from 'react'
-
-export interface ChatMessage {
-  id: string
-  role: 'user' | 'npc'
-  type: 'TEXT' | 'IMAGE' | 'YOUTUBE'
-  content: string
-  timestamp?: string
-  avatarUrl?: string
-}
+import type { ChatMessage } from '@/types/chat'
 
 export function ChatBubble({ message }: { message: ChatMessage }) {
   const isUser = message.role === 'user'

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -38,13 +38,18 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} gap-2 mb-3`}>
       {!isUser && message.avatarUrl && (
-        <Image
-          src={message.avatarUrl}
-          alt="avatar"
-          width={32}
-          height={32}
-          className="rounded-full self-end"
-        />
+        <div className="relative w-8 h-8 overflow-hidden rounded-full self-end flex-shrink-0">
+          <Image
+            src={message.avatarUrl}
+            alt="avatar"
+            fill
+            className="object-cover"
+            style={{
+              transform: `translate(${message.avatarX ?? 0}%, ${message.avatarY ?? 0}%) scale(${message.avatarScale ?? 1})`,
+            }}
+            unoptimized
+          />
+        </div>
       )}
       <div className="max-w-[70%]">
         <div

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -36,9 +36,9 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
 
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} gap-2 mb-3`}>
-      {!isUser && (
+      {!isUser && message.avatarUrl && (
         <Image
-          src={message.avatarUrl || '/next.svg'}
+          src={message.avatarUrl}
           alt="avatar"
           width={32}
           height={32}

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -16,6 +16,7 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
             width={200}
             height={200}
             className="rounded-lg"
+            unoptimized
           />
         )
       case 'YOUTUBE':

--- a/src/data/characters.ts
+++ b/src/data/characters.ts
@@ -8,6 +8,9 @@ export interface CharacterRule {
 export interface CharacterData {
   id: string
   avatarUrl?: string
+  avatarX?: number
+  avatarY?: number
+  avatarScale?: number
   greeting: ResponseItem[]
   rules: CharacterRule[]
   defaultResponses: ResponseItem[]
@@ -17,6 +20,9 @@ export const characters: Record<string, CharacterData> = {
   default: {
     id: 'default',
     avatarUrl: '/next.svg',
+    avatarX: 0,
+    avatarY: 0,
+    avatarScale: 1,
     greeting: [{ type: 'text', value: '你好，我是預設角色' }],
     rules: [
       { keywords: ['你好', 'hi'], responses: [{ type: 'text', value: '很高興見到你！' }] },
@@ -79,6 +85,9 @@ export async function getCharacter(id: string): Promise<CharacterData> {
       return {
         id,
         avatarUrl: data.avatarUrl || characters.default.avatarUrl,
+        avatarX: typeof data.avatarX === 'number' ? data.avatarX : characters.default.avatarX,
+        avatarY: typeof data.avatarY === 'number' ? data.avatarY : characters.default.avatarY,
+        avatarScale: typeof data.avatarScale === 'number' ? data.avatarScale : characters.default.avatarScale,
         greeting,
         rules: others.map((r) => ({
           keywords: r.keywords || [],

--- a/src/data/characters.ts
+++ b/src/data/characters.ts
@@ -1,0 +1,20 @@
+export interface CharacterData {
+  id: string
+  avatarUrl?: string
+  greeting: string
+  rules: { keywords: string[]; response: string }[]
+  defaultResponse: string
+}
+
+export const characters: Record<string, CharacterData> = {
+  default: {
+    id: 'default',
+    avatarUrl: '/next.svg',
+    greeting: '你好，我是預設角色',
+    rules: [
+      { keywords: ['你好', 'hi'], response: '很高興見到你！' },
+      { keywords: ['再見', 'bye'], response: '下次見！' },
+    ],
+    defaultResponse: '我還在學習，聽不太懂你的意思。',
+  },
+}

--- a/src/data/characters.ts
+++ b/src/data/characters.ts
@@ -6,6 +6,8 @@ export interface CharacterData {
   defaultResponse: string
 }
 
+import type { CharacterDoc } from '@/types'
+
 export const characters: Record<string, CharacterData> = {
   default: {
     id: 'default',
@@ -17,4 +19,65 @@ export const characters: Record<string, CharacterData> = {
     ],
     defaultResponse: '我還在學習，聽不太懂你的意思。',
   },
+}
+
+let cachedDb: import('firebase/firestore').Firestore | null = null
+
+async function getDb() {
+  if (cachedDb) return cachedDb
+  const { initializeApp, getApps, getApp } = await import('firebase/app')
+  const { getFirestore } = await import('firebase/firestore')
+
+  const firebaseConfig = {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  }
+
+  const app = getApps().length ? getApp() : initializeApp(firebaseConfig)
+  cachedDb = getFirestore(app)
+  return cachedDb
+}
+
+export async function getCharacter(id: string): Promise<CharacterData> {
+  if (id === 'default') return characters.default
+  try {
+    const { doc, getDoc } = await import('firebase/firestore')
+    const db = await getDb()
+    const snap = await getDoc(doc(db, 'characters', id))
+    if (snap.exists()) {
+      const data = snap.data() as CharacterDoc
+      const first = (data.rules || []).find((r) => r.type === 'firstLogin')
+      const def = (data.rules || []).find((r) => r.type === 'default')
+      const others = (data.rules || []).filter(
+        (r) => r.type !== 'firstLogin' && r.type !== 'default',
+      )
+      const greetValue = first?.responses?.[0]?.value
+      const defValue = def?.responses?.[0]?.value
+      return {
+        id,
+        avatarUrl: data.avatarUrl || characters.default.avatarUrl,
+        greeting:
+          typeof greetValue === 'string'
+            ? greetValue
+            : `你好，我是${data.name || 'NPC'}`,
+        rules: others.map((r) => ({
+          keywords: r.keywords || [],
+          response:
+            typeof r.responses?.[0]?.value === 'string'
+              ? (r.responses[0].value as string)
+              : '',
+        })),
+        defaultResponse:
+          typeof defValue === 'string'
+            ? defValue
+            : characters.default.defaultResponse,
+      }
+    }
+  } catch (err) {
+    console.error('getCharacter failed', err)
+  }
+  return characters.default
 }

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { ChatMessage } from '@/components/ChatBubble'
+import type { ChatMessage } from '@/types/chat'
 
 interface InitResponse {
   conversationId: string

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -38,7 +38,14 @@ export function useChat(characterId: string) {
         } else {
           setConversationId(id)
           const res = await fetch(`/api/chat/history?conversationId=${id}`)
-          if (!res.ok) throw new Error('history failed')
+          if (!res.ok) {
+            if (res.status === 404) {
+              localStorage.removeItem(storageKey)
+              setConversationId(null)
+              return init(true)
+            }
+            throw new Error('history failed')
+          }
           const data: HistoryResponse = await res.json()
           setMessages(data.messages || [])
         }
@@ -73,7 +80,13 @@ export function useChat(characterId: string) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ conversationId, message: text }),
       })
-      if (!res.ok) throw new Error('post failed')
+      if (!res.ok) {
+        if (res.status === 404) {
+          clear()
+          throw new Error('not found')
+        }
+        throw new Error('post failed')
+      }
       const data: PostResponse = await res.json()
       setMessages((prev) => [...prev, ...data.messages])
     } catch {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -20,9 +20,10 @@ export function useChat(characterId: string) {
   const [conversationId, setConversationId] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const storageKey = `conversationId-${characterId}`
 
   useEffect(() => {
-    const id = localStorage.getItem('conversationId')
+    const id = localStorage.getItem(storageKey)
     async function fetchInit() {
       try {
         setLoading(true)
@@ -31,7 +32,7 @@ export function useChat(characterId: string) {
           const res = await fetch(`/api/chat/init?characterId=${characterId}`)
           if (!res.ok) throw new Error('init failed')
           const data: InitResponse = await res.json()
-          localStorage.setItem('conversationId', data.conversationId)
+          localStorage.setItem(storageKey, data.conversationId)
           setConversationId(data.conversationId)
           setMessages(data.messages || [])
         } else {
@@ -48,7 +49,7 @@ export function useChat(characterId: string) {
       }
     }
     fetchInit()
-  }, [characterId])
+  }, [characterId, storageKey])
 
   async function send(text: string) {
     if (!conversationId) return
@@ -79,7 +80,7 @@ export function useChat(characterId: string) {
   }
 
   function clear() {
-    localStorage.removeItem('conversationId')
+    localStorage.removeItem(storageKey)
     setConversationId(null)
     setMessages([])
   }

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import type { ChatMessage } from '@/types/chat'
 
 interface InitResponse {
@@ -22,9 +22,9 @@ export function useChat(characterId: string) {
   const [error, setError] = useState<string | null>(null)
   const storageKey = `conversationId-${characterId}`
 
-  useEffect(() => {
-    const id = localStorage.getItem(storageKey)
-    async function fetchInit() {
+  const init = useCallback(
+    async (force?: boolean) => {
+      const id = force ? null : localStorage.getItem(storageKey)
       try {
         setLoading(true)
         setError(null)
@@ -47,9 +47,13 @@ export function useChat(characterId: string) {
       } finally {
         setLoading(false)
       }
-    }
-    fetchInit()
-  }, [characterId, storageKey])
+    },
+    [characterId, storageKey],
+  )
+
+  useEffect(() => {
+    init()
+  }, [init])
 
   async function send(text: string) {
     if (!conversationId) return
@@ -83,6 +87,7 @@ export function useChat(characterId: string) {
     localStorage.removeItem(storageKey)
     setConversationId(null)
     setMessages([])
+    init(true)
   }
 
   return { messages, send, clear, loading, error }

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,0 +1,88 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { ChatMessage } from '@/components/ChatBubble'
+
+interface InitResponse {
+  conversationId: string
+  messages: ChatMessage[]
+}
+
+interface HistoryResponse {
+  messages: ChatMessage[]
+}
+
+interface PostResponse {
+  messages: ChatMessage[]
+}
+
+export function useChat(characterId: string) {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [conversationId, setConversationId] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const id = localStorage.getItem('conversationId')
+    async function fetchInit() {
+      try {
+        setLoading(true)
+        setError(null)
+        if (!id) {
+          const res = await fetch(`/api/chat/init?characterId=${characterId}`)
+          if (!res.ok) throw new Error('init failed')
+          const data: InitResponse = await res.json()
+          localStorage.setItem('conversationId', data.conversationId)
+          setConversationId(data.conversationId)
+          setMessages(data.messages || [])
+        } else {
+          setConversationId(id)
+          const res = await fetch(`/api/chat/history?conversationId=${id}`)
+          if (!res.ok) throw new Error('history failed')
+          const data: HistoryResponse = await res.json()
+          setMessages(data.messages || [])
+        }
+      } catch {
+        setError('載入失敗')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchInit()
+  }, [characterId])
+
+  async function send(text: string) {
+    if (!conversationId) return
+    const local: ChatMessage = {
+      id: String(Date.now()),
+      role: 'user',
+      type: 'TEXT',
+      content: text,
+      timestamp: new Date().toISOString(),
+    }
+    setMessages((prev) => [...prev, local])
+    try {
+      setError(null)
+      setLoading(true)
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ conversationId, message: text }),
+      })
+      if (!res.ok) throw new Error('post failed')
+      const data: PostResponse = await res.json()
+      setMessages((prev) => [...prev, ...data.messages])
+    } catch {
+      setError('送出失敗')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function clear() {
+    localStorage.removeItem('conversationId')
+    setConversationId(null)
+    setMessages([])
+  }
+
+  return { messages, send, clear, loading, error }
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -6,4 +6,7 @@ export interface ChatMessage {
   content: string
   timestamp?: string
   avatarUrl?: string
+  avatarX?: number
+  avatarY?: number
+  avatarScale?: number
 }

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,9 @@
+export type MessageType = 'TEXT' | 'IMAGE' | 'YOUTUBE'
+export interface ChatMessage {
+  id: string
+  role: 'user' | 'npc'
+  type: MessageType
+  content: string
+  timestamp?: string
+  avatarUrl?: string
+}


### PR DESCRIPTION
## Summary
- replace landing page with chat interface
- add `ChatBubble` component supporting text, image and YouTube messages
- create `useChat` hook to manage conversation and API calls

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684bd0e7ea808326a899f81ac99ed433