### PR TITLE
Add chat textarea and button styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,12 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Custom styles used on the chat page */
+.chat-textarea {
+  @apply flex-1 border rounded p-2 resize-none h-10;
+}
+
+.send-button {
+  @apply px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50;
+}


### PR DESCRIPTION
## Summary
- add `.chat-textarea` and `.send-button` classes in global stylesheet

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e567486f88326aa040c4d9561fa7c