### PR TITLE
Improve message editing and chat timing

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -44,7 +44,7 @@ export function useChat(characterId: string) {
           localStorage.setItem(storageKey, data.conversationId)
           setConversationId(data.conversationId)
           setMessages([])
-          await appendMessagesSequentially(data.messages || [])
+          void appendMessagesSequentially(data.messages || [])
         } else {
           setConversationId(id)
           const res = await fetch(`/api/chat/history?conversationId=${id}`)
@@ -98,7 +98,7 @@ export function useChat(characterId: string) {
         throw new Error('post failed')
       }
       const data: PostResponse = await res.json()
-      await appendMessagesSequentially(data.messages)
+      void appendMessagesSequentially(data.messages)
     } catch {
       setError('送出失敗')
     } finally {


### PR DESCRIPTION
## Summary
- allow deleting a reply by dragging its handle outward
- open file dialog immediately when choosing **Add Image** in rule editor
- show sequential NPC messages with 1s delay

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850faba9e0083269a394d416b65b469