### PR TITLE
Add task management

### DIFF
--- a/src/app/admin/characters/[id]/edit.client.tsx
+++ b/src/app/admin/characters/[id]/edit.client.tsx
@@ -159,17 +159,44 @@ export default function EditCharacterPage() {
         </label>
         <label className="flex flex-col gap-1">
           所屬任務
-          <select
-            multiple
-            className="border rounded px-2 py-1 h-28"
-            value={tasks}
-            onChange={(e) =>
-              setTasks(
-                Array.from(e.target.selectedOptions).map((o) => o.value)
+          <div className="flex flex-wrap gap-1 mb-1">
+            {tasks.map((tid) => {
+              const t = taskValue?.docs.find((d) => d.id === tid)
+              if (!t) return null
+              const data = t.data() as TaskDoc
+              return (
+                <span
+                  key={tid}
+                  className="px-2 py-1 text-sm bg-gray-200 rounded flex items-center gap-1"
+                >
+                  {data.name}
+                  <button
+                    type="button"
+                    className="text-xs text-red-600"
+                    onClick={() =>
+                      setTasks((arr) => arr.filter((id) => id !== tid))
+                    }
+                  >
+                    ×
+                  </button>
+                </span>
               )
-            }
+            })}
+          </div>
+          <select
+            className="border rounded px-2 py-1"
+            onChange={(e) => {
+              const val = e.target.value
+              if (!val) return
+              setTasks((arr) =>
+                arr.includes(val) ? arr : [...arr, val]
+              )
+              e.target.value = ''
+            }}
           >
+            <option value="">選擇任務</option>
             {taskValue?.docs.map((doc) => {
+              if (tasks.includes(doc.id)) return null
               const d = doc.data() as TaskDoc
               return (
                 <option key={doc.id} value={doc.id}>

--- a/src/app/admin/characters/actions.ts
+++ b/src/app/admin/characters/actions.ts
@@ -24,6 +24,7 @@ export async function createCharacter(name: string, file: File) {
     avatarScale: 1,
     avatarX: 0,
     avatarY: 0,
+    tasks: [],
     rules: [
       {
         keywords: [],
@@ -58,6 +59,7 @@ export async function updateCharacter(
   avatarScale?: number,
   avatarX?: number,
   avatarY?: number,
+  tasks?: string[],
 ) {
   if (!auth.currentUser) {
     await signInAnonymously(auth);
@@ -113,6 +115,10 @@ export async function updateCharacter(
     await uploadBytes(imgRef, file);
     const url = await getDownloadURL(imgRef);
     data.avatarUrl = url;
+  }
+
+  if (tasks) {
+    data.tasks = tasks
   }
 
   await updateDoc(doc(db, 'characters', id), data);

--- a/src/app/admin/tasks/[id]/edit.client.tsx
+++ b/src/app/admin/tasks/[id]/edit.client.tsx
@@ -1,0 +1,119 @@
+'use client'
+export const dynamic = 'force-dynamic'
+
+import { useState, useEffect } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { doc, collection } from 'firebase/firestore'
+import { useDocument, useCollection } from 'react-firebase-hooks/firestore'
+import { db } from '@/libs/firebase'
+import { updateTask, deleteTask } from '../actions'
+import type { TaskDoc, CharacterDoc } from '@/types'
+import Image from 'next/image'
+import QRCode from 'qrcode'
+import Link from 'next/link'
+
+export default function EditTaskPage() {
+  const { id } = useParams<{ id: string }>()
+  const router = useRouter()
+  const [taskSnap] = useDocument(id ? doc(db, 'tasks', id) : undefined)
+  const [charSnap] = useCollection(collection(db, 'characters'))
+  const task = taskSnap?.data() as TaskDoc | undefined
+  const characters = charSnap?.docs.map(d => ({ id: d.id, data: d.data() as CharacterDoc })) || []
+
+  const [name, setName] = useState('')
+  const [desc, setDesc] = useState('')
+  const [selected, setSelected] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (task) {
+      setName(task.name)
+      setDesc(task.description || '')
+    }
+  }, [task])
+  useEffect(() => {
+    if (charSnap) {
+      const ids = charSnap.docs.filter(d => (d.data().tasks || []).includes(id!)).map(d => d.id)
+      setSelected(ids)
+    }
+  }, [charSnap, id])
+
+  if (!taskSnap) return <div className="p-6">Loading...</div>
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      await updateTask(id!, name, desc, selected)
+      router.push('/admin/tasks')
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm('確定要刪除這個任務嗎？')) return
+    await deleteTask(id!)
+    router.push('/admin/tasks')
+  }
+
+  async function handleDownloadQr(cid: string, cname: string) {
+    const url = `${window.location.origin}/chat/${cid}`
+    try {
+      const dataUrl = await QRCode.toDataURL(url, { width: 450 })
+      const link = document.createElement('a')
+      link.href = dataUrl
+      link.download = `${cname || 'QR'}QrCode.png`
+      link.click()
+    } catch {
+      alert('Failed to generate QR code')
+    }
+  }
+
+  return (
+    <div className="p-6 flex flex-col gap-4 max-w-md">
+      <h1 className="text-xl">編輯任務</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <label className="flex flex-col gap-1">
+          任務名稱
+          <input className="border rounded px-2 py-1" value={name} onChange={(e)=>setName(e.target.value)} required />
+        </label>
+        <label className="flex flex-col gap-1">
+          任務說明
+          <textarea className="border rounded px-2 py-1" value={desc} onChange={(e)=>setDesc(e.target.value)} />
+        </label>
+        <label className="flex flex-col gap-1">
+          人物
+          <select multiple className="border rounded px-2 py-1 h-28" value={selected} onChange={(e)=>setSelected(Array.from(e.target.selectedOptions).map(o=>o.value))}>
+            {characters.map(ch => (
+              <option key={ch.id} value={ch.id}>{ch.data.name}</option>
+            ))}
+          </select>
+        </label>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <div className="flex gap-2">
+          <button type="submit" disabled={loading} className="px-4 py-2 bg-black text-white rounded disabled:opacity-50">儲存</button>
+          <button type="button" onClick={handleDelete} className="px-4 py-2 text-red-600">刪除</button>
+        </div>
+      </form>
+      <h2 className="text-lg mt-4">人物列表</h2>
+      <div className="flex flex-col gap-2">
+        {characters.filter(ch => selected.includes(ch.id)).map(ch => (
+          <div key={ch.id} className="flex items-center gap-2">
+            <div className="relative w-10 h-10 overflow-hidden rounded-full">
+              <Image src={ch.data.avatarUrl || 'https://placehold.co/40x40.png'} alt={ch.data.name} fill className="object-cover" style={{transform:`translate(${ch.data.avatarX??0}%,${ch.data.avatarY??0}%) scale(${ch.data.avatarScale??1})`}} />
+            </div>
+            <span className="flex-1">{ch.data.name}</span>
+            <Link href={`/admin/characters/${ch.id}`} className="text-blue-500 underline">編輯</Link>
+            <Link href={`/chat/${ch.id}`} className="text-blue-500 underline">聊天</Link>
+            <button className="text-blue-500 underline" onClick={()=>handleDownloadQr(ch.id, ch.data.name)}>下載QR</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/tasks/[id]/edit.client.tsx
+++ b/src/app/admin/tasks/[id]/edit.client.tsx
@@ -88,11 +88,36 @@ export default function EditTaskPage() {
         </label>
         <label className="flex flex-col gap-1">
           人物
-          <select multiple className="border rounded px-2 py-1 h-28" value={selected} onChange={(e)=>setSelected(Array.from(e.target.selectedOptions).map(o=>o.value))}>
+          <div className="border rounded px-2 py-1 max-h-40 overflow-auto flex flex-col gap-1">
             {characters.map(ch => (
-              <option key={ch.id} value={ch.id}>{ch.data.name}</option>
+              <label key={ch.id} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="mr-1"
+                  value={ch.id}
+                  checked={selected.includes(ch.id)}
+                  onChange={e => {
+                    const val = ch.id
+                    setSelected(arr =>
+                      e.target.checked ? [...arr, val] : arr.filter(id => id !== val)
+                    )
+                  }}
+                />
+                <div className="relative w-6 h-6 overflow-hidden rounded-full">
+                  <Image
+                    src={ch.data.avatarUrl || 'https://placehold.co/24x24.png'}
+                    alt={ch.data.name}
+                    fill
+                    className="object-cover"
+                    style={{
+                      transform: `translate(${ch.data.avatarX ?? 0}%,${ch.data.avatarY ?? 0}%) scale(${ch.data.avatarScale ?? 1})`
+                    }}
+                  />
+                </div>
+                <span>{ch.data.name}</span>
+              </label>
             ))}
-          </select>
+          </div>
         </label>
         {error && <p className="text-red-600 text-sm">{error}</p>}
         <div className="flex gap-2">

--- a/src/app/admin/tasks/[id]/page.tsx
+++ b/src/app/admin/tasks/[id]/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import dynamicImport from 'next/dynamic'
+
+const EditTaskClient = dynamicImport(() => import('./edit.client'), { ssr: false })
+export const dynamic = 'force-dynamic'
+export default function EditTaskPage() {
+  return <EditTaskClient />
+}

--- a/src/app/admin/tasks/actions.ts
+++ b/src/app/admin/tasks/actions.ts
@@ -1,0 +1,43 @@
+import { collection, addDoc, doc, updateDoc, deleteDoc, getDocs, arrayUnion, arrayRemove, serverTimestamp } from 'firebase/firestore'
+import { signInAnonymously } from 'firebase/auth'
+import { db, auth } from '@/libs/firebase'
+
+export async function createTask(name: string, description: string, characterIds: string[]) {
+  if (!auth.currentUser) {
+    await signInAnonymously(auth)
+  }
+  const docRef = await addDoc(collection(db, 'tasks'), { name, description, createdAt: serverTimestamp() })
+  for (const cid of characterIds) {
+    await updateDoc(doc(db, 'characters', cid), { tasks: arrayUnion(docRef.id) })
+  }
+}
+
+export async function updateTask(id: string, name: string, description: string, characterIds: string[]) {
+  if (!auth.currentUser) {
+    await signInAnonymously(auth)
+  }
+  await updateDoc(doc(db, 'tasks', id), { name, description })
+  const snaps = await getDocs(collection(db, 'characters'))
+  for (const snap of snaps.docs) {
+    const has = (snap.data().tasks || []).includes(id)
+    const should = characterIds.includes(snap.id)
+    if (should && !has) {
+      await updateDoc(snap.ref, { tasks: arrayUnion(id) })
+    } else if (!should && has) {
+      await updateDoc(snap.ref, { tasks: arrayRemove(id) })
+    }
+  }
+}
+
+export async function deleteTask(id: string) {
+  if (!auth.currentUser) {
+    await signInAnonymously(auth)
+  }
+  await deleteDoc(doc(db, 'tasks', id))
+  const snaps = await getDocs(collection(db, 'characters'))
+  for (const snap of snaps.docs) {
+    if ((snap.data().tasks || []).includes(id)) {
+      await updateDoc(snap.ref, { tasks: arrayRemove(id) })
+    }
+  }
+}

--- a/src/app/admin/tasks/list.client.tsx
+++ b/src/app/admin/tasks/list.client.tsx
@@ -1,0 +1,92 @@
+'use client'
+export const dynamic = 'force-dynamic'
+
+import { useState } from 'react'
+import { useCollection } from 'react-firebase-hooks/firestore'
+import { collection, orderBy, query } from 'firebase/firestore'
+import { db } from '@/libs/firebase'
+import { DataTable, Column } from '@/components/data-table'
+import { Drawer } from '@/components/drawer'
+import Link from 'next/link'
+import { createTask, deleteTask } from './actions'
+import type { TaskDoc, CharacterDoc } from '@/types'
+
+function NewTaskForm({ characters, onCreated }: { characters: {id: string, data: CharacterDoc}[], onCreated: () => void }) {
+  const [name, setName] = useState('')
+  const [desc, setDesc] = useState('')
+  const [selected, setSelected] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      await createTask(name, desc, selected)
+      onCreated()
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <label className="flex flex-col gap-1">
+        任務名稱
+        <input className="border rounded px-2 py-1" value={name} onChange={(e)=>setName(e.target.value)} required />
+      </label>
+      <label className="flex flex-col gap-1">
+        任務說明
+        <textarea className="border rounded px-2 py-1" value={desc} onChange={(e)=>setDesc(e.target.value)} />
+      </label>
+      <label className="flex flex-col gap-1">
+        加入人物
+        <select multiple className="border rounded px-2 py-1 h-28" value={selected} onChange={(e)=>setSelected(Array.from(e.target.selectedOptions).map(o=>o.value))}>
+          {characters.map(ch => (
+            <option key={ch.id} value={ch.id}>{ch.data.name}</option>
+          ))}
+        </select>
+      </label>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <button type="submit" disabled={loading} className="self-start px-4 py-2 bg-black text-white rounded disabled:opacity-50">
+        {loading ? '建立中...' : '建立'}
+      </button>
+    </form>
+  )
+}
+
+export default function TasksPage() {
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [taskSnap] = useCollection(query(collection(db,'tasks'), orderBy('createdAt','desc')))
+  const [charSnap] = useCollection(collection(db,'characters'))
+
+  const tasks = taskSnap?.docs.map(doc => ({ id: doc.id, ...(doc.data() as TaskDoc) })) || []
+  const characters = charSnap?.docs.map(doc => ({ id: doc.id, data: doc.data() as CharacterDoc })) || []
+
+  const columns: Column<(typeof tasks)[number]>[] = [
+    { header: 'Name', accessor: row => row.name },
+    { header: 'Description', accessor: row => row.description || '' },
+    { header: '', accessor: row => (
+        <Link href={`/admin/tasks/${row.id}`} className="text-blue-500 underline">管理</Link>
+      ) },
+    { header: '', accessor: row => (
+        <button className="text-red-600 underline" onClick={async ()=>{ if(confirm('確定要刪除這個任務嗎？')) await deleteTask(row.id) }}>刪除</button>
+      )},
+  ]
+
+  return (
+    <div className="p-6">
+      <div className="flex justify-end mb-4">
+        <button className="px-4 py-2 bg-black text-white rounded" onClick={()=>setDrawerOpen(true)}>新增任務</button>
+      </div>
+      <DataTable columns={columns} data={tasks} />
+      <Drawer open={drawerOpen} onClose={()=>setDrawerOpen(false)}>
+        <h2 className="text-xl mb-4">新增任務</h2>
+        <NewTaskForm characters={characters} onCreated={()=>setDrawerOpen(false)} />
+      </Drawer>
+    </div>
+  )
+}

--- a/src/app/admin/tasks/list.client.tsx
+++ b/src/app/admin/tasks/list.client.tsx
@@ -8,6 +8,7 @@ import { db } from '@/libs/firebase'
 import { DataTable, Column } from '@/components/data-table'
 import { Drawer } from '@/components/drawer'
 import Link from 'next/link'
+import Image from 'next/image'
 import { createTask, deleteTask } from './actions'
 import type { TaskDoc, CharacterDoc } from '@/types'
 
@@ -44,11 +45,36 @@ function NewTaskForm({ characters, onCreated }: { characters: {id: string, data:
       </label>
       <label className="flex flex-col gap-1">
         加入人物
-        <select multiple className="border rounded px-2 py-1 h-28" value={selected} onChange={(e)=>setSelected(Array.from(e.target.selectedOptions).map(o=>o.value))}>
+        <div className="border rounded px-2 py-1 max-h-40 overflow-auto flex flex-col gap-1">
           {characters.map(ch => (
-            <option key={ch.id} value={ch.id}>{ch.data.name}</option>
+            <label key={ch.id} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                className="mr-1"
+                value={ch.id}
+                checked={selected.includes(ch.id)}
+                onChange={e => {
+                  const val = ch.id
+                  setSelected(arr =>
+                    e.target.checked ? [...arr, val] : arr.filter(id => id !== val)
+                  )
+                }}
+              />
+              <div className="relative w-6 h-6 overflow-hidden rounded-full">
+                <Image
+                  src={ch.data.avatarUrl || 'https://placehold.co/24x24.png'}
+                  alt={ch.data.name}
+                  fill
+                  className="object-cover"
+                  style={{
+                    transform: `translate(${ch.data.avatarX ?? 0}%,${ch.data.avatarY ?? 0}%) scale(${ch.data.avatarScale ?? 1})`
+                  }}
+                />
+              </div>
+              <span>{ch.data.name}</span>
+            </label>
           ))}
-        </select>
+        </div>
       </label>
       {error && <p className="text-red-600 text-sm">{error}</p>}
       <button type="submit" disabled={loading} className="self-start px-4 py-2 bg-black text-white rounded disabled:opacity-50">

--- a/src/app/admin/tasks/page.tsx
+++ b/src/app/admin/tasks/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import dynamicImport from 'next/dynamic'
+
+const TasksPageClient = dynamicImport(() => import('./list.client'), { ssr: false })
+export const dynamic = 'force-dynamic'
+export default function TasksPage() {
+  return <TasksPageClient />
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,4 +19,11 @@ export interface CharacterDoc {
   avatarX?: number
   avatarY?: number
   rules: Rule[]
+  tasks?: string[]
+}
+
+export interface TaskDoc {
+  name: string
+  description?: string
+  createdAt?: import('firebase/firestore').Timestamp
 }


### PR DESCRIPTION
## Summary
- add tasks to character model
- implement Firestore actions for tasks
- add task selection in character edit page
- build task management pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68526b04d7088326992e8556ebd850aa