### PR TITLE
Improve chat interface styling

### DIFF
--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -35,7 +35,7 @@ export default function CharacterChatPage() {
 
   return (
     <div className="h-dvh flex flex-col max-w-md mx-auto w-full bg-gradient-to-b from-white to-teal-50 dark:bg-neutral-950">
-      <header className="p-4 border-b flex justify-between items-center bg-gradient-to-r from-teal-500 to-teal-600 text-white">
+      <header className="p-4 border-b flex justify-between items-center bg-gradient-to-r from-teal-400 to-teal-500 text-white shadow">
         <h1 className="font-semibold text-lg">{data?.name || 'NPC Chat'}</h1>
         <button className="text-sm text-white" onClick={clear}>
           重設對話

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -22,7 +22,9 @@ export default function CharacterChatPage() {
   const listRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    listRef.current?.scrollTo(0, listRef.current.scrollHeight)
+    const node = listRef.current
+    if (!node) return
+    node.scrollTo({ top: node.scrollHeight, behavior: 'smooth' })
   }, [messages])
 
   function handleSubmit(e: React.FormEvent) {
@@ -58,7 +60,10 @@ export default function CharacterChatPage() {
           </div>
         </div>
       )}
-      <div ref={listRef} className="flex-1 overflow-y-auto p-4 space-y-2 pb-28">
+      <div
+        ref={listRef}
+        className="flex-1 overflow-y-auto p-4 space-y-2 pb-28 scroll-smooth"
+      >
         {messages.map((m: ChatMessage) => (
           <ChatBubble key={m.id} message={m} />
         ))}

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -21,10 +21,26 @@ export default function CharacterChatPage() {
   const [text, setText] = useState('')
   const listRef = useRef<HTMLDivElement | null>(null)
 
+  function smoothScroll(node: HTMLElement, duration = 800) {
+    const start = node.scrollTop
+    const end = node.scrollHeight - node.clientHeight
+    const change = end - start
+    const startTime = performance.now()
+
+    function animate(now: number) {
+      const elapsed = now - startTime
+      const progress = Math.min(elapsed / duration, 1)
+      node.scrollTop = start + change * progress
+      if (progress < 1) requestAnimationFrame(animate)
+    }
+
+    requestAnimationFrame(animate)
+  }
+
   useEffect(() => {
     const node = listRef.current
     if (!node) return
-    node.scrollTo({ top: node.scrollHeight, behavior: 'smooth' })
+    smoothScroll(node, 1000)
   }, [messages])
 
   function handleSubmit(e: React.FormEvent) {

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -68,8 +68,9 @@ export default function CharacterChatPage() {
         onSubmit={handleSubmit}
         className="sticky bottom-0 bg-white dark:bg-neutral-900 p-4 flex gap-2 border-t"
       >
-        <textarea
-          className="chat-textarea"
+        <input
+          type="text"
+          className="chat-input"
           value={text}
           onChange={(e) => setText(e.target.value)}
         />

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useRef, useState } from 'react'
+import { useRef, useState, useEffect } from 'react'
 import Image from 'next/image'
 import { useParams } from 'next/navigation'
 import { doc } from 'firebase/firestore'
@@ -21,15 +21,16 @@ export default function CharacterChatPage() {
   const [text, setText] = useState('')
   const listRef = useRef<HTMLDivElement | null>(null)
 
+  useEffect(() => {
+    listRef.current?.scrollTo(0, listRef.current.scrollHeight)
+  }, [messages])
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!text.trim()) return
     send(text.trim())
     setText('')
     ;(document.activeElement as HTMLElement | null)?.blur()
-    setTimeout(() => {
-      listRef.current?.scrollTo(0, listRef.current.scrollHeight)
-    }, 50)
   }
 
   return (

--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -33,8 +33,8 @@ export default function CharacterChatPage() {
   }
 
   return (
-    <div className="h-dvh flex flex-col max-w-md mx-auto w-full bg-teal-50 dark:bg-neutral-950">
-      <header className="p-4 border-b flex justify-between items-center bg-teal-600 text-white">
+    <div className="h-dvh flex flex-col max-w-md mx-auto w-full bg-gradient-to-b from-white to-teal-50 dark:bg-neutral-950">
+      <header className="p-4 border-b flex justify-between items-center bg-gradient-to-r from-teal-500 to-teal-600 text-white">
         <h1 className="font-semibold text-lg">{data?.name || 'NPC Chat'}</h1>
         <button className="text-sm text-white" onClick={clear}>
           重設對話

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,8 +27,8 @@ body {
 }
 
 /* Custom styles used on the chat page */
-.chat-textarea {
-  @apply flex-1 border border-gray-300 rounded-lg p-2 resize-none h-10;
+.chat-input {
+  @apply flex-1 border border-gray-300 rounded-lg p-2 h-10;
 }
 
 .send-button {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #e0f7f7;
+  --background: #f2f9fb;
   --foreground: #00332e;
 }
 
@@ -28,9 +28,9 @@ body {
 
 /* Custom styles used on the chat page */
 .chat-textarea {
-  @apply flex-1 border rounded p-2 resize-none h-10;
+  @apply flex-1 border border-gray-300 rounded-lg p-2 resize-none h-10;
 }
 
 .send-button {
-  @apply px-4 py-2 bg-teal-600 text-white rounded disabled:opacity-50;
+  @apply px-4 py-2 bg-teal-600 text-white rounded-lg shadow disabled:opacity-50;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,3 +34,16 @@ body {
 .send-button {
   @apply px-4 py-2 bg-teal-600 text-white rounded-lg shadow disabled:opacity-50;
 }
+@keyframes float-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.float-in {
+  animation: float-in 0.3s ease both;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,11 +28,11 @@ body {
 
 /* Custom styles used on the chat page */
 .chat-input {
-  @apply flex-1 border border-gray-300 rounded-lg p-2 h-10;
+  @apply flex-1 border border-gray-300 rounded-lg p-2 h-10 shadow-inner focus:outline-none;
 }
 
 .send-button {
-  @apply px-4 py-2 bg-teal-600 text-white rounded-lg shadow disabled:opacity-50;
+  @apply px-4 py-2 bg-teal-500 hover:bg-teal-600 text-white rounded-lg shadow disabled:opacity-50;
 }
 @keyframes float-in {
   from {

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -68,7 +68,7 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
   }
 
   return (
-    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} gap-2 mb-3`}>
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} gap-2 mb-3 float-in`}>
       {!isUser && message.avatarUrl && (
         <div className="relative w-8 h-8 overflow-hidden rounded-full self-end flex-shrink-0">
           <Image

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -89,11 +89,11 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
             isUser
               ? 'bg-gradient-to-br from-blue-50 to-blue-100 text-gray-800'
               : 'bg-gradient-to-br from-green-50 to-green-100 text-gray-800'
-          }`}
+          } ${message.typing ? 'animate-pulse' : ''}`}
         >
-          {renderContent()}
+          {message.typing ? <span className="tracking-widest">...</span> : renderContent()}
         </div>
-        {message.timestamp && (
+        {message.timestamp && !message.typing && (
           <time className="block mt-1 text-xs text-gray-500 text-right">
             {new Date(message.timestamp).toLocaleTimeString()}
           </time>

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -1,12 +1,19 @@
 'use client'
 import Image from 'next/image'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch'
 import type { ChatMessage } from '@/types/chat'
 
 export function ChatBubble({ message }: { message: ChatMessage }) {
   const isUser = message.role === 'user'
   const [showImage, setShowImage] = useState(false)
+  useEffect(() => {
+    if (showImage) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
+  }, [showImage])
 
   function renderContent() {
     switch (message.type) {
@@ -24,7 +31,7 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
             />
             {showImage && (
               <div
-                className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center"
+                className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center"
                 onClick={() => setShowImage(false)}
               >
                 <div

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -85,8 +85,10 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
       )}
       <div className="max-w-[70%]">
         <div
-          className={`px-3 py-2 rounded-lg text-sm break-words ${
-            isUser ? 'bg-teal-600 text-white' : 'bg-gray-200 dark:bg-neutral-800'
+          className={`px-4 py-3 rounded-xl shadow text-sm break-words ${
+            isUser
+              ? 'bg-gradient-to-br from-blue-50 to-blue-100 text-gray-800'
+              : 'bg-gradient-to-br from-green-50 to-green-100 text-gray-800'
           }`}
         >
           {renderContent()}

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -39,6 +39,7 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
                   </button>
                   <TransformWrapper>
                     <TransformComponent wrapperClass="max-h-screen max-w-screen">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src={message.content}
                         alt="image"
@@ -85,10 +86,10 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
       )}
       <div className="max-w-[70%]">
         <div
-          className={`px-4 py-3 rounded-xl shadow text-sm break-words ${
+          className={`px-4 py-3 rounded-xl shadow-md text-sm break-words ${
             isUser
-              ? 'bg-gradient-to-br from-blue-50 to-blue-100 text-gray-800'
-              : 'bg-gradient-to-br from-green-50 to-green-100 text-gray-800'
+              ? 'bg-gradient-to-br from-blue-50 via-blue-100 to-white text-gray-800'
+              : 'bg-gradient-to-br from-green-50 via-green-100 to-white text-gray-800'
           } ${message.typing ? 'animate-pulse' : ''}`}
         >
           {message.typing ? <span className="tracking-widest">...</span> : renderContent()}

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -26,7 +26,17 @@ export function useChat(characterId: string) {
     for (let i = 0; i < msgs.length; i++) {
       setMessages((prev) => [...prev, msgs[i]])
       if (i < msgs.length - 1) {
+        const typingId = `typing-${Date.now()}-${i}`
+        const typingMsg: ChatMessage = {
+          id: typingId,
+          role: 'npc',
+          type: 'TEXT',
+          content: '...',
+          typing: true,
+        }
+        setMessages((prev) => [...prev, typingMsg])
         await new Promise((res) => setTimeout(res, 1000))
+        setMessages((prev) => prev.filter((m) => m.id !== typingId))
       }
     }
   }

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -9,4 +9,5 @@ export interface ChatMessage {
   avatarX?: number
   avatarY?: number
   avatarScale?: number
+  typing?: boolean
 }


### PR DESCRIPTION
## Summary
- update background color variables
- add border and shadow styles for input and send button
- redesign `ChatBubble` component with light gradient message bubbles
- apply gradient backgrounds to the chat page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68536dd00f448326a128ee09044849d4