### PR TITLE
Fix scroll speed and image overlay

### DIFF
--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -21,26 +21,10 @@ export default function CharacterChatPage() {
   const [text, setText] = useState('')
   const listRef = useRef<HTMLDivElement | null>(null)
 
-  function smoothScroll(node: HTMLElement, duration = 800) {
-    const start = node.scrollTop
-    const end = node.scrollHeight - node.clientHeight
-    const change = end - start
-    const startTime = performance.now()
-
-    function animate(now: number) {
-      const elapsed = now - startTime
-      const progress = Math.min(elapsed / duration, 1)
-      node.scrollTop = start + change * progress
-      if (progress < 1) requestAnimationFrame(animate)
-    }
-
-    requestAnimationFrame(animate)
-  }
-
   useEffect(() => {
     const node = listRef.current
     if (!node) return
-    smoothScroll(node, 1000)
+    node.scrollTo({ top: node.scrollHeight, behavior: 'smooth' })
   }, [messages])
 
   function handleSubmit(e: React.FormEvent) {

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Image from 'next/image'
 import React, { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch'
 import type { ChatMessage } from '@/types/chat'
 
@@ -29,34 +30,36 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
               onClick={() => setShowImage(true)}
               unoptimized
             />
-            {showImage && (
-              <div
-                className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center"
-                onClick={() => setShowImage(false)}
-              >
+            {showImage &&
+              createPortal(
                 <div
-                  className="relative max-w-full max-h-full"
-                  onClick={(e) => e.stopPropagation()}
+                  className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center"
+                  onClick={() => setShowImage(false)}
                 >
-                  <button
-                    className="absolute top-2 right-2 text-white text-2xl z-10"
-                    onClick={() => setShowImage(false)}
+                  <div
+                    className="relative max-w-full max-h-full"
+                    onClick={(e) => e.stopPropagation()}
                   >
-                    ×
-                  </button>
-                  <TransformWrapper>
-                    <TransformComponent wrapperClass="max-h-screen max-w-screen">
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={message.content}
-                        alt="image"
-                        className="max-h-screen max-w-screen"
-                      />
-                    </TransformComponent>
-                  </TransformWrapper>
-                </div>
-              </div>
-            )}
+                    <button
+                      className="absolute top-2 right-2 text-white text-2xl z-10"
+                      onClick={() => setShowImage(false)}
+                    >
+                      ×
+                    </button>
+                    <TransformWrapper>
+                      <TransformComponent wrapperClass="max-h-screen max-w-screen">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={message.content}
+                          alt="image"
+                          className="max-h-screen max-w-screen"
+                        />
+                      </TransformComponent>
+                    </TransformWrapper>
+                  </div>
+                </div>,
+                document.body,
+              )}
           </>
         )
       case 'YOUTUBE':

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -35,7 +35,7 @@ export function useChat(characterId: string) {
           typing: true,
         }
         setMessages((prev) => [...prev, typingMsg])
-        await new Promise((res) => setTimeout(res, 1000))
+        await new Promise((res) => setTimeout(res, 1500))
         setMessages((prev) => prev.filter((m) => m.id !== typingId))
       }
     }


### PR DESCRIPTION
## Summary
- make chat auto-scroll faster using browser smooth scroll
- set typing delay to 1.5 seconds
- render image viewer overlay in portal so entire UI dims

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853908b85f88326b75bb9f098564f40